### PR TITLE
Tune `SLOWLOG get` length

### DIFF
--- a/lambda_function.rb
+++ b/lambda_function.rb
@@ -8,7 +8,7 @@ require 'dogapi'
 require_relative 'lib/slowlog_check'
 
 LOGGER = Logger.new($stdout)
-LOGGER.level = Logger::DEBUG
+LOGGER.level = Logger::INFO
 LOGGER.freeze
 
 def event_time

--- a/spec/slowlog_check_spec.rb
+++ b/spec/slowlog_check_spec.rb
@@ -147,7 +147,7 @@ describe SlowlogCheck do
     context 'redis has 567 entries and no zeroeth entry' do
       let(:sauce) {
           Array.new(567) { |x|
-            redis_slowlog(x, Time.utc(2020,04,20,03,20,00) + x, x)
+            redis_slowlog(x + 1, Time.utc(2020,04,20,03,20,00) + x, x)
           }.reverse
         }
       before(:each) do


### PR DESCRIPTION
https://github.com/scribd/elasticache-slowlog-to-datadog/issues/2

Implements: 

> start with SLOWLOG get 128; look for index 0, or length < 128; else increase get length. If response length increases, repeat until it does not, or index 0 is found.