### PR TITLE
feat: Add support for the 4 permutations of Elasticache redis endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following parameters need to be supplied to the lambda function.
 
 Environment Variable | Type   | Description                                                   | Required | Default
 ---------------------|--------|---------------------------------------------------------------|----------|---------
-REDIS_HOST           | string | FQDN of the elasticache redis endpoint                        | yes      | -
+REDIS_HOST           | string | FQDN or URI of the elasticache redis endpoint                 | yes      | -
 DATADOG_API_KEY      | string | Datadog API Key                                               | no       | -
 DATADOG_APP_KEY      | string | Datadog API Key                                               | no       | -
 NAMESPACE            | string | "namespace" tag to apply to Datadog metric                    | yes      | -
@@ -49,7 +49,7 @@ DO NOT use this script in production environments, as it will CPU thrash the tar
 
 Environment Variable | Type   | Description                                                   | Required | Default
 ---------------------|--------|---------------------------------------------------------------|----------|---------
-REDIS_HOST           | string | FQDN of the elasticache redis endpoint                        | yes      | -
+REDIS_HOST           | string | FQDN or URI of the elasticache redis endpoint                 | yes      | -
 
 
 # Requirements

--- a/inject_slow_query.rb
+++ b/inject_slow_query.rb
@@ -5,14 +5,14 @@
 
 require 'logger'
 require 'redis'
+require_relative 'lib/slowlog_check'
 
 LOGGER = Logger.new($stdout)
 LOGGER.level = Logger::WARN
 
-REDIS = Redis.new(
-  host: ENV.fetch('REDIS_HOST'),
-  ssl: :true
-  )
+REDIS = SlowlogCheck::Redis.new(
+  host: ENV.fetch('REDIS_HOST')
+).redis
 
 if ARGV[0].nil?
   raise "Specify milliseconds to inject as the first positional argument to `#{__FILE__}`"

--- a/lambda_function.rb
+++ b/lambda_function.rb
@@ -3,13 +3,11 @@
 
 require 'logger'
 require 'date'
-require 'redis'
 require 'dogapi'
 require_relative 'lib/slowlog_check'
 
 LOGGER = Logger.new($stdout)
 LOGGER.level = Logger::INFO
-LOGGER.freeze
 
 def event_time
   # DateTime because Time does not natively parse AWS CloudWatch Event time
@@ -23,6 +21,7 @@ def log_context
   LOGGER.debug(@event)
   LOGGER.info "Event time: #{event_time}."
 end
+
 
 def lambda_handler(event: {}, context: {})
   @event = event
@@ -49,10 +48,9 @@ def lambda_handler(event: {}, context: {})
         ENV.fetch('DATADOG_API_KEY'),
         ENV.fetch('DATADOG_APP_KEY')
       ),
-      redis: Redis.new(
-        host: ENV.fetch('REDIS_HOST'),
-        ssl: :true
-      ),
+      redis: {
+        host: ENV.fetch('REDIS_HOST')
+      },
       namespace: ENV.fetch('NAMESPACE'),
       env: ENV.fetch('ENV'),
       metricname: ENV.fetch('METRICNAME', 'elasticache.slowlog')

--- a/lib/slowlog_check/redis.rb
+++ b/lib/slowlog_check/redis.rb
@@ -1,0 +1,98 @@
+require 'redis'
+require 'uri'
+
+class SlowlogCheck::Redis
+  MAXLENGTH = 1048576 #255 levels of recursion for #
+
+  def initialize(opts)
+    @host = opts[:host]
+  end
+
+  def params
+    if cluster_mode_enabled?
+      {
+        cluster: [uri],
+        port: port,
+        ssl: tls_mode?
+      }
+    else
+      {
+        host: hostname,
+        port: port,
+        ssl: tls_mode?
+      }
+    end
+  end
+
+  def redis
+    @redis ||= Redis.new(params)
+  end
+
+  def replication_group
+    if tls_mode?
+      matches[:second]
+    else
+      matches[:first]
+    end
+  end
+
+
+  def slowlog(length = 128)
+    resp = redis.slowlog('get', length)
+
+    return resp if length > MAXLENGTH
+    return resp if did_i_get_it_all?(resp)
+    return slowlog(length * 2)
+  end
+
+  private
+
+  def cluster_mode_enabled?
+    if tls_mode?
+      matches[:first] == 'clustercfg'
+    else
+      matches[:third] == ''
+    end
+  end
+
+  def did_i_get_it_all?(slowlog)
+    slowlog[-1][0] == 0
+  end
+
+  def hostname
+    URI.parse(@host).hostname or
+      @host
+  end
+
+  def matches
+    redis_uri_regex.match(@host)
+  end
+
+  def port
+    regex_port = matches[:port].to_i
+    if regex_port > 0
+      regex_port
+    else
+      6379
+    end
+  end
+
+  def uri
+    'redis' +
+      lambda { tls_mode? ? 's' : '' }.call +
+      '://' +
+      hostname +
+      ':' +
+      port.to_s
+  end
+
+  def redis_uri_regex
+    /((?<scheme>redi[s]+)\:\/\/){0,1}(?<first>[0-9A-Za-z_-]+)\.(?<second>[0-9A-Za-z_-]+)\.{0,1}(?<third>[0-9A-Za-z_]*)\.(?<region>[0-9A-Za-z_-]+)\.cache\.amazonaws\.com:{0,1}(?<port>[0-9]*)/
+  end
+
+  def tls_mode?
+    matches[:scheme] == 'rediss' or
+      %w[master clustercfg].include?(matches[:first])
+  end
+
+end

--- a/spec/slowlog_check/redis_spec.rb
+++ b/spec/slowlog_check/redis_spec.rb
@@ -1,0 +1,265 @@
+require 'spec_helper'
+
+describe SlowlogCheck::Redis do
+  before(:example) { allow(Redis).to receive(:new) }
+
+  ##
+  # Shared Contexts
+  #
+  # See https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Endpoints.html
+  #  for the four permutations of host strings
+
+  # Cluster Mode Disabled or Enabled : TLS or not : hostname form or uri form
+
+  shared_context 'CMD:no TLS' do
+    let(:redis) { described_class.new( host: 'replication-group-123_abc.xxxxxx.nodeId.us-example-3x.cache.amazonaws.com' ) }
+  end
+  shared_context 'CMD:no TLS:uri' do
+    let(:redis) { described_class.new( host: 'redis://replication-group-123_abc.xxxxxx.nodeId.us-example-3x.cache.amazonaws.com:42' ) }
+  end
+  shared_context 'CMD:TLS' do
+    let(:redis) { described_class.new( host: 'master.replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com' ) }
+  end
+  shared_context 'CMD:TLS:uri' do
+    let(:redis) { described_class.new( host: 'rediss://master.replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com:42' ) }
+  end
+
+  # cluster Mode Enabled
+
+  shared_context 'CME:no TLS' do
+    let(:redis) { described_class.new( host: 'replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com' ) }
+  end
+  shared_context 'CME:no TLS:uri' do
+    let(:redis) { described_class.new( host: 'redis://replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com:42' ) }
+  end
+  shared_context 'CME:TLS' do
+    let(:redis) { described_class.new( host: 'clustercfg.replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com' ) }
+  end
+  shared_context 'CME:TLS:uri' do
+    let(:redis) { described_class.new( host: 'rediss://clustercfg.replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com:42' ) }
+  end
+
+
+  describe 'Parsing parameters' do
+
+    describe '#params' do
+
+      context 'REDIS_HOST' do
+
+        context 'Cluster mode disabled' do
+
+          context 'CMD:no TLS' do
+            include_context 'CMD:no TLS'
+            subject { redis.params }
+
+            it { is_expected.to eq(
+              host: 'replication-group-123_abc.xxxxxx.nodeId.us-example-3x.cache.amazonaws.com',
+              port: 6379,
+              ssl: false
+            )}
+          end
+
+          context 'CMD:no TLS:uri' do
+            include_context 'CMD:no TLS:uri'
+            subject { redis.params }
+
+            it { is_expected.to eq(
+              host: 'replication-group-123_abc.xxxxxx.nodeId.us-example-3x.cache.amazonaws.com',
+              port: 42,
+              ssl: false
+            )}
+          end
+
+          context 'CMD:TLS' do
+            include_context 'CMD:TLS'
+            subject { redis.params }
+
+            it { is_expected.to eq(
+              host: 'master.replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com',
+              port: 6379,
+              ssl: true
+            )}
+          end
+
+          context 'CMD:TLS:uri' do
+            include_context 'CMD:TLS:uri'
+            subject { redis.params }
+
+            it { is_expected.to eq(
+              host: 'master.replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com',
+              port: 42,
+              ssl: true
+            )}
+          end
+
+        end
+
+        context 'Cluster mode enabled' do
+
+          context 'CME:no TLS' do
+            include_context 'CME:no TLS'
+            subject { redis.params }
+
+            it { is_expected.to eq(
+              cluster: ['redis://replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com:6379'],
+              port: 6379,
+              ssl: false
+            )}
+          end
+
+          context 'CME:no TLS:uri' do
+            include_context 'CME:no TLS:uri'
+            subject { redis.params }
+
+            it { is_expected.to eq(
+              cluster: ['redis://replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com:42'],
+              port: 42,
+              ssl: false
+            )}
+          end
+
+          context 'CME:TLS' do
+            include_context 'CME:TLS'
+            subject { redis.params }
+
+            it { is_expected.to eq(
+              cluster: ['rediss://clustercfg.replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com:6379'],
+              port: 6379,
+              ssl: true
+            )}
+          end
+
+          context 'CME:TLS:uri' do
+            include_context 'CME:TLS:uri'
+            subject { redis.params }
+
+            it { is_expected.to eq(
+              cluster: ['rediss://clustercfg.replication-group-123_abc.xxxxxx.us-example-3x.cache.amazonaws.com:42'],
+              port: 42,
+              ssl: true
+            )}
+          end
+        end
+      end
+    end
+
+    describe '#replication_group' do
+
+        context 'Cluster mode disabled' do
+
+          context 'CMD:no TLS' do
+            include_context 'CMD:no TLS'
+            subject { redis.replication_group }
+
+            it { is_expected.to eq('replication-group-123_abc') }
+          end
+
+          context 'CMD:TLS' do
+            include_context 'CMD:TLS'
+            subject { redis.replication_group }
+
+            it { is_expected.to eq('replication-group-123_abc') }
+          end
+
+        end
+
+        context 'Cluster mode enabled' do
+
+          context 'CME:no TLS' do
+            include_context 'CME:no TLS'
+            subject { redis.replication_group }
+
+            it { is_expected.to eq('replication-group-123_abc') }
+          end
+
+          context 'CME:TLS' do
+            include_context 'CME:TLS'
+            subject { redis.replication_group }
+
+            it { is_expected.to eq('replication-group-123_abc') }
+          end
+        end
+      end
+  end
+
+
+  describe '#slowlog' do
+    include_context 'CME:TLS' # which context doesn't matter, so pick any one
+
+    # mock the redis-rb gem
+    let(:redis_rb) { double }
+    before(:example) { allow(redis).to receive(:redis).and_return(redis_rb) }
+
+    describe '#slowlog.length' do
+      context 'redis has 4 entries' do
+        before(:each) do
+          # see spec_helper for redis_slowlog definition
+          allow(redis_rb).to receive(:slowlog).with('get', 128) {
+            [
+              redis_slowlog(3, Time.utc(2020, 4, 20, 4, 19, 45), 400000),
+              redis_slowlog(2, Time.utc(2020, 4, 20, 4, 19, 15), 100000),
+              redis_slowlog(1, Time.utc(2020, 4, 20, 4, 18, 45), 100000),
+              redis_slowlog(0, Time.utc(2020, 4, 20, 4, 18, 15), 200000),
+            ]
+          }
+        end
+
+        subject { redis.slowlog.length }
+        it { is_expected.to eq(4) }
+      end
+
+      context 'redis has 129 entries and a zeroeth entry' do
+        before(:each) do
+          allow(redis_rb).to receive(:slowlog).with('get', 128) {
+            Array.new(129) { |x|
+              redis_slowlog(x, Time.utc(2020, 4, 20, 4, 0, 0) + x, x * 1000)
+            }.reverse[0..127]
+          }
+
+          allow(redis_rb).to receive(:slowlog).with('get', 256) {
+            Array.new(129) { |x|
+              redis_slowlog(x, Time.utc(2020, 4, 20, 4, 0, 0) + x, x * 1000)
+            }.reverse
+          }
+
+        end
+
+        subject { redis.slowlog.length }
+        it { is_expected.to eq(129) }
+      end
+
+      context 'redis has 1048576 * 2 + 1 entries and a zeroeth entry' do
+        let(:sauce) {
+          Array.new(1048576 * 2 + 1) { |x|
+            redis_slowlog(x, 1587352800, x) #lettuce not create so many unnecessary Time objects
+          }.reverse
+        }
+        before(:each) do
+          allow(redis_rb).to receive(:slowlog) { |_, number|
+            sauce[0..number - 1]
+          }
+        end
+
+        subject { redis.slowlog.length }
+        it { is_expected.to eq(1048576 * 2) } # with the last entry dropped
+      end
+
+      context 'redis has 567 entries and no zeroeth entry' do
+        let(:sauce) {
+          Array.new(567) { |x|
+            redis_slowlog(x + 1, Time.utc(2020, 4, 20, 3, 20, 0) + x, x)
+          }.reverse
+        }
+        before(:each) do
+          allow(redis_rb).to receive(:slowlog) { |_, number|
+            sauce[0..number - 1]
+          }
+        end
+
+        subject { redis.slowlog.length }
+        it { is_expected.to eq(567) }
+
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,3 +98,20 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+require 'slowlog_check'
+
+def redis_slowlog(index, time, microseconds, command = 'eval')
+  [
+    index,
+    time.to_i,
+    microseconds,
+    [
+      command,
+      "",
+      "0"
+    ],
+    "192.0.2.40:55700",
+    ""
+  ]
+end


### PR DESCRIPTION
chore: move redis bits to subclass

Fixes https://github.com/scribd/elasticache-slowlog-to-datadog/issues/5
See https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Endpoints.html